### PR TITLE
Add shutdown provider

### DIFF
--- a/LSP.sc
+++ b/LSP.sc
@@ -177,7 +177,9 @@ LSPConnection {
 			Log('LanguageServer.quark').info("Found method provider: %", provider);
 
 			// Preprocess param values into a usable state
-			preprocessor.value(params);
+			params !? {
+				preprocessor.value(params);
+			};
 
 			Deferred().using({
 				provider.handleRequest(method, params);

--- a/Providers/ShutdownProvider.sc
+++ b/Providers/ShutdownProvider.sc
@@ -1,0 +1,41 @@
+// https://microsoft.github.io/language-server-protocol/specifications/specification-current/#shutdown
+ShutdownProvider : LSPProvider {
+	var receivedShutdown = false;
+
+	*methodNames {
+		^[
+			"shutdown",
+			"exit"
+		]
+	}
+
+	*clientCapabilityName { ^nil }
+	*serverCapabilityName { ^nil }
+
+	init {
+		|clientCapabilities|
+		// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#declarationClientCapabilities
+	}
+
+	options {
+		// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncOptions
+		^()
+	}
+
+	handleRequest {
+		|method, params|
+		var code;
+		Log('LanguageServer.quark').info("Handling: %", method);
+		switch (method)
+		{ 'shutdown' } {
+			Log('LanguageServer.quark').info("Preparing to shutdown");
+			receivedShutdown = true;
+			^(result: "null", code: 0);
+		}
+		{ 'exit' } {
+			code = receivedShutdown.if(0, 1);
+			code.exit;
+			^nil;
+		}
+	}
+}


### PR DESCRIPTION
Hi!

This is an attempt to implement [shutdown requests](https://microsoft.github.io/language-server-protocol/specification#shutdown).

This is useful for the [stdio adapter](https://github.com/davidgranstrom/sclang-lsp-stdio) that communicates with the nvim LSP client so that we can shut down the node process on nvim exit and thus freeing the open ports.

I did not implement this part of the spec:
> If a server receives requests after a shutdown request those requests should error with InvalidRequest.

We could perhaps set a flag in `LSPConnection` to signal when a `shutdown` request has been received, but I did not want to complicate the code until I get to know the code base a bit better.

