### PR TITLE
Evaluate: Apply preProcessor if it exists

### DIFF
--- a/Providers/EvaluateProvider.sc
+++ b/Providers/EvaluateProvider.sc
@@ -37,6 +37,7 @@ EvaluateProvider : LSPProvider {
 
 		result = ();
 
+		source = thisProcess.interpreter.preProcessor.value(source) ?? { source };
 		function = source.compile();
 		if (function.isNil) {
 			result[\compileError] = "Compile error?"
@@ -53,7 +54,7 @@ EvaluateProvider : LSPProvider {
 			} {
 				|error|
 				result[\error] = error.errorString;
-				
+
 				if (postResult) {
 					error.reportError
 				}


### PR DESCRIPTION
Fixes issue 24 logged for scztt/vscode-supercollider.

User code should pass through the interpreter's preProcessor function before being compiled.

This commit restores support for preprocessor-based dialects.