### PR TITLE
Formatting provider: Defer initialization into a StartUp block

### DIFF
--- a/Providers/TextDocumentFormattingProvider.sc
+++ b/Providers/TextDocumentFormattingProvider.sc
@@ -10,8 +10,10 @@ TextDocumentFormattingProvider : LSPProvider {
     *serverCapabilityName { ^"documentFormattingProvider" }
     
     *initClass {
-        if (formatterEnabled) {
-            formatter = CodeFormatter();
+        StartUp.add {
+            if (formatterEnabled) {
+                formatter = CodeFormatter();
+            }
         }
     }
     


### PR DESCRIPTION
If TextDocumentFormattingProvider is initialized immediately, then the user has no opportunity to configure formatterEnabled in startup.scd. The user should not be required to edit class definitions by hand for configuration. Putting the actual creation of the CodeFormatter object into a StartUp block means that startup.scd runs first, and then the formatterEnabled check happens later.

I haven't done a comprehensive review of the other providers to look for other configuration options that need similar treatment.