### PR TITLE
SignatureProvider: Remove stray debugging postln

### DIFF
--- a/Providers/SignatureHelpProvider.sc
+++ b/Providers/SignatureHelpProvider.sc
@@ -38,7 +38,6 @@ SignatureHelpProvider : LSPProvider {
                 ownerClass = methodName !? _.asSymbol !? _.asClass !? _.class;
                 
                 methodName !? _.asSymbol !? _.asClass !? _.class
-                    !? _.postln
                     !? {
                         |classes|
                         classes = [classes] ++ classes.superclasses;


### PR DESCRIPTION
If I type `SynthDef(`, the post window says:

```
Meta_SynthDef
```

... and it continues to post this for basically every keystroke.

It took a while, but I finally found the line where this is happening. This PR removes the line (which is otherwise a no-op).

It's a quite maddening behavior, so I hope this could be merged sooner rather than later.

(BTW for this repository, do you prefer PRs for develop or master?)