### PR TITLE
Prevent "nil does not understand keys" error in Ndef completion search

### DIFF
--- a/CompletionHandlers/LSPCompletionHandler_singleton.sc
+++ b/CompletionHandlers/LSPCompletionHandler_singleton.sc
@@ -77,7 +77,14 @@
 
 +Ndef {
     *isDefClass { ^true }
-        *prGetNames { ^this.all[Server.default.name].keys } // @TODO Search across all servers here?
+    *prGetNames {
+        var proxyspace = this.all[Server.default.name];
+        ^if(proxyspace.notNil) {
+            proxyspace.keys
+        } {
+            Set.new
+        }
+    } // @TODO Search across all servers here?
 }
 
 +Pdef { *isDefClass { ^true } }


### PR DESCRIPTION
The line `^this.all[Server.default.name].keys` assumes that every server object has a ProxySpace repository. This isn't true: the repository is created with the first Ndef for that server. So your first attempt to use Ndef in a session will produce a "'keys' not understood" error. This PR guards against this.

(I haven't considered the "@TODO" -- I'm not changing the spec, just fixing a detail that made it not work according to the spec.)

```
ERROR: Message 'keys' not understood.
RECEIVER:
   nil
ARGS:
PATH: /home/dlm/.config/SuperCollider/startup.scd

PROTECTED CALL STACK:
	Meta_MethodError:new	0x55e03950f880
		arg this = DoesNotUnderstandError
		arg what = nil
		arg receiver = nil
	Meta_DoesNotUnderstandError:new	0x55e039511bc0
		arg this = DoesNotUnderstandError
		arg receiver = nil
		arg selector = keys
		arg args = []
	Object:doesNotUnderstand	0x55e03864d5c0
		arg this = nil
		arg selector = keys
		arg args = nil
	a FunctionDef	0x55e03bcc6a00
		sourceCode = "{
                |prefixClass, trigger, completion, provideCompletionsFunc|
                var results, defNames;
                
                defNames = prefixClass.prGetNames.asArray.sort;
                defNames = defNames.collect({ |name| \"\\\\\" ++ name.asString });
                
                Log('LanguageServer.quark').info(\"Starting with defs: %\", defNames);
                
                // defNames = defNames.select({
                // 	|name|
                // 	...etc..."
		arg prefixClass = Ndef
		arg trigger = (
		arg completion = )
		arg provideCompletionsFunc = a Function
		var results = nil
		var defNames = nil
	LSPCompletionHandler:handle	0x55e03b6ab740
		arg this = a LSPCompletionHandler
		arg prefix = Ndef
		arg trigger = (
		arg completion = )
		var deferredResult = Deferred(952455718)
... snip...


[Error - 08:56:39] Request textDocument/completion failed.
  Message: DoesNotUnderstandError
  Code: -1943623135 
```