### PR TITLE
Show Node Tree: Update ExecuteCommandProvider.sc to call function correctly

### DIFF
--- a/Providers/ExecuteCommandProvider.sc
+++ b/Providers/ExecuteCommandProvider.sc
@@ -47,6 +47,9 @@ ExecuteCommandProvider : LSPProvider {
             'supercollider.internal.dumpNodeTreeWithControls': {
                 Server.default.queryAllNodes(true)
             },
+            'supercollider.internal.showTree': {
+                Server.default.plotTree()
+            },
             'supercollider.internal.plotTree': {
                 Server.default.plotTree()
             },


### PR DESCRIPTION
Fixed show tree command. Left plot method and added show to call the same function so it doesn't fail.