### PR TITLE
Add supercollider server status notification

### DIFF
--- a/LSPFeature.sc
+++ b/LSPFeature.sc
@@ -84,7 +84,8 @@ LSPRequest : LSPFeature {
 }
 
 LSPNotification : LSPFeature {
-    sendNotification { |params|
+    sendNotification {
+        |params|
         ^server.prSendMessage((
             method: this.methodNames[0],
             params: params

--- a/LSPFeature.sc
+++ b/LSPFeature.sc
@@ -82,3 +82,12 @@ LSPRequest : LSPFeature {
         ^server.prHandleRequest(this.methodNames[0], params)
     }
 }
+
+LSPNotification : LSPFeature {
+    sendNotification { |params|
+        ^server.prSendMessage((
+            method: this.methodNames[0],
+            params: params
+        ))
+    }
+}

--- a/Notifications/ServerStatusNotification.sc
+++ b/Notifications/ServerStatusNotification.sc
@@ -1,0 +1,50 @@
+ServerStatusNotification : LSPNotification {
+    *methodNames {
+		^[
+			"supercollider/serverStatus",
+		]
+	}
+
+    *clientCapabilityName { ^"supercollider.serverStatus" }
+	*serverCapabilityName { ^"serverStatus" }
+
+    init {
+        // Register the updateState callbacks on a server
+        var registerServer = { | server update |
+            SimpleController(server)
+                .put(\serverRunning, { this.updateState(server.name) })
+                .put(\counts, { this.updateState(server.name) });
+                //server.startAliveThread;
+            if (update) { this.updateState };
+        };
+
+        // Whenever a server is added, call registerServer
+        SimpleController(Server)
+				.put(\serverAdded, { | serverClass what server | registerServer.value(server, true) });
+		Server.named.do(registerServer.value(_, false));
+        this.updateState;
+    }
+
+    updateState { |serverName|
+        // Currently, only the default server is supported.
+        if (Server.default.name == serverName, {
+            var params = (
+                \running: Server.default.serverRunning,
+                \unresponsive: Server.default.unresponsive,
+                \avgCPU: (Server.default.avgCPU ? 0.0).round(0.1),
+                \peakCPU: (Server.default.peakCPU ? 0.0).round(0.1),
+                \numUGens: Server.default.numUGens ? 0,
+                \numSynths: Server.default.numSynths ? 0,
+                \numGroups: Server.default.numGroups ? 0,
+                \numSynthDefs: Server.default.numSynthDefs ? 0
+            );
+
+            this.sendNotification(params);
+        })
+    }
+
+    options {
+		^(
+		)
+	}
+}


### PR DESCRIPTION
Hi,

I added a new custom notification to the LSP. This notification will send status information about the Supercollider Server to the LSP client.

Once this is merged I can create another MR for the VSCode extension to show the data in the Status Bar. Here is already a preview:

![grafik](https://github.com/scztt/LanguageServer.quark/assets/176220/ef6bf205-0f48-4bd2-b721-69c28364062c)
