### PR TITLE
Run CmdPeriod.run() inside the LSPConnection handler thread.

### DIFF
--- a/Providers/ExecuteCommandProvider.sc
+++ b/Providers/ExecuteCommandProvider.sc
@@ -60,7 +60,9 @@ ExecuteCommandProvider : LSPProvider {
                 Server.default.stopRecording()
             },
             'supercollider.internal.cmdPeriod': {
-                CmdPeriod.run();
+                LSPConnection.handlerThread.next({
+                    CmdPeriod.run();
+                })
             }
         )
     }


### PR DESCRIPTION
ServerTree.add or CmdPeriod.add hooks can update the surrounding environment. Therefore CmdPeriod.run() has to be executed in the LSPConnection handler thread which defines it's own environment.

This fixes: https://github.com/scztt/vscode-supercollider/issues/59

