### PR TITLE
handleMessage: don't reply to notification

### DIFF
--- a/LSP.sc
+++ b/LSP.sc
@@ -227,7 +227,9 @@ LSPConnection {
                     "Provider % is returning *itself* from onReceived instead of providing an explicit nil or non-nil return value!".format(provider.class).warn;
                 };
                 
-                this.prHandleResponse(id, result);
+                // messages without ids are notifications and don't need a response
+                // (responses without ids cause errors in neovim)
+                id !? { this.prHandleResponse(id, result) }
             }, {
                 |error|
                 // @TODO handle error


### PR DESCRIPTION
a Notification is a message without an id, and shouldn't generate a Response.
LSP.sc currently calls handleResponse on every message it receives, generating invalid responses, lacking both "id" and "jsonrpc".
Neovim errors with `"INVALID_SERVER_MESSAGE"` when receiving a Response without id.

This PR avoids replying to messages that lack the "id" field.

## Example:
Neovim sends:
```json
{
  "jsonrpc": "2.0",
  "method": "textDocument/didOpen",
  "params": {...}
}
```
LSP finds `TextDocumentProvider` to handle didOpen, which then returns
`nil`, causing this reponse to be sent:
```json
{ "result": null }
```
But the original message was a notification and didn't need a response.
In fact, if I understood correctly, this response would be invalid according to [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage), as every Message needs a "jsonrpc" field, and every Response needs an "id" field too.
What's worse is that such response without id will cause an error in Neovim, stopping the LSP. I don't know if vscode(-likes) are less strict.

