### PR TITLE
Windows Support - Handle paths in an OS-independent way

### DIFF
--- a/LSPDatabase.sc
+++ b/LSPDatabase.sc
@@ -232,7 +232,7 @@ LSPDatabase {
     *renderMethodLocation {
         |method|
         ^(
-            uri: "file:///%".format(method.filenameSymbol.asString.replace("\\","/")),
+            uri: method.filenameSymbol.asString.pathToFileURI,
             range: this.renderMethodRange(method)
         )
     }
@@ -240,7 +240,7 @@ LSPDatabase {
     *renderClassLocation {
         |class|
         ^(
-            uri: "file:///%".format(class.filenameSymbol.asString.replace("\\","/")),
+            uri: class.filenameSymbol.asString.pathToFileURI,
             range: this.renderClassRange(class)
         )
     }

--- a/LSPDatabase.sc
+++ b/LSPDatabase.sc
@@ -205,7 +205,7 @@ LSPDatabase {
     
     *renderMethodRange {
         |method|
-        var file = File(method.filenameSymbol.asString, "r");
+        var file = File(method.filenameSymbol.asString.replace("\\","/"), "r");
         var methodFileSource = file.readAllString();
         var lineChar = methodFileSource.charToLineChar(method.charPos);
         
@@ -232,7 +232,7 @@ LSPDatabase {
     *renderMethodLocation {
         |method|
         ^(
-            uri: "file://%".format(method.filenameSymbol),
+            uri: "file:///%".format(method.filenameSymbol.asString.replace("\\","/")),
             range: this.renderMethodRange(method)
         )
     }
@@ -240,7 +240,7 @@ LSPDatabase {
     *renderClassLocation {
         |class|
         ^(
-            uri: "file://%".format(class.filenameSymbol),
+            uri: "file:///%".format(class.filenameSymbol.asString.replace("\\","/")),
             range: this.renderClassRange(class)
         )
     }

--- a/LSPDatabase.sc
+++ b/LSPDatabase.sc
@@ -205,7 +205,7 @@ LSPDatabase {
     
     *renderMethodRange {
         |method|
-        var file = File(method.filenameSymbol.asString.replace("\\","/"), "r");
+        var file = File(method.filenameSymbol.asString, "r");
         var methodFileSource = file.readAllString();
         var lineChar = methodFileSource.charToLineChar(method.charPos);
         

--- a/Providers/EvaluateProvider.sc
+++ b/Providers/EvaluateProvider.sc
@@ -176,7 +176,7 @@ EvaluateProvider : LSPProvider {
                 };
                 
                 out << "\t%:%\t".format(ownerClass, methodName).padRight(30)
-                    << def.filenameSymbol.asString.pathToFileURI
+                    << "(%)".format(def.filenameSymbol.asString.pathToFileURI)
                     << Char.nl;
             } {
                 out << "\ta FunctionDef\t%\n".format(currentFrame.address);

--- a/Providers/EvaluateProvider.sc
+++ b/Providers/EvaluateProvider.sc
@@ -176,7 +176,7 @@ EvaluateProvider : LSPProvider {
                 };
                 
                 out << "\t%:%\t".format(ownerClass, methodName).padRight(30)
-                    << "(file:///%)".format(def.filenameSymbol.asString.replace("\\","/"))
+                    << def.filenameSymbol.asString.pathToFileURI
                     << Char.nl;
             } {
                 out << "\ta FunctionDef\t%\n".format(currentFrame.address);

--- a/Providers/EvaluateProvider.sc
+++ b/Providers/EvaluateProvider.sc
@@ -176,7 +176,7 @@ EvaluateProvider : LSPProvider {
                 };
                 
                 out << "\t%:%\t".format(ownerClass, methodName).padRight(30)
-                    << "(file://%)".format(def.filenameSymbol)
+                    << "(file:///%)".format(def.filenameSymbol.asString.replace("\\","/"))
                     << Char.nl;
             } {
                 out << "\ta FunctionDef\t%\n".format(currentFrame.address);

--- a/Providers/InitializeProvider.sc
+++ b/Providers/InitializeProvider.sc
@@ -63,14 +63,12 @@ InitializeProvider : LSPProvider {
             |folders|
             folders.do {
                 |folder|
-                    folder["uri"].copy.replace("file:///", "").urlDecode.postln;
-                server.workspaceFolders.add(folder["uri"].copy.replace("file:///", "").urlDecode)
+                server.workspaceFolders.add(folder["uri"].copy.fileURIToPath)
             };
         } ?? {
             initializeParams["rootUri"] ?? initializeParams["rootPath"] !? {
                 |root|
-                    root.copy.replace("file:///", "").urlDecode.postln;
-                server.workspaceFolders.add(root.copy.replace("file:///", "").urlDecode)
+                server.workspaceFolders.add(root.copy.fileURIToPath)
             };
         };
         

--- a/Providers/InitializeProvider.sc
+++ b/Providers/InitializeProvider.sc
@@ -63,12 +63,14 @@ InitializeProvider : LSPProvider {
             |folders|
             folders.do {
                 |folder|
-                server.workspaceFolders.add(folder["uri"].copy.replace("file://", "").urlDecode)
+                    folder["uri"].copy.replace("file:///", "").urlDecode.postln;
+                server.workspaceFolders.add(folder["uri"].copy.replace("file:///", "").urlDecode)
             };
         } ?? {
             initializeParams["rootUri"] ?? initializeParams["rootPath"] !? {
                 |root|
-                server.workspaceFolders.add(root.copy.replace("file://", "").urlDecode)
+                    root.copy.replace("file:///", "").urlDecode.postln;
+                server.workspaceFolders.add(root.copy.replace("file:///", "").urlDecode)
             };
         };
         

--- a/extString.sc
+++ b/extString.sc
@@ -33,4 +33,30 @@
         
         ^(currentIndex + character)
     }
+
+    /*
+    Given an absolute file path in OSX, Windows, or Linux format, return a file URI
+    that will be understood by the LSP client.
+    */
+    pathToFileURI {
+        ^Platform.case(
+            \osx, { "file://" ++ this },
+            \windows, { "file:///" ++ this.replace("\\", "/") },
+            \linux, { "file://" ++ this },
+            { "file://" ++ this }
+        )
+    }
+
+    /*
+    Reverse of pathToFileURI - given a file URI, returns a path in the format of the 
+    current OS.
+    */
+    fileURIToPath {
+        ^(Platform.case(
+            \osx, { this.replace("file://", "") },
+            \windows, { this.replace("file:///", "").replace("/", "\\") },
+            \linux, { this.replace("file://", "") },
+            { this.replace("file://", "") }
+        ).urlDecode)
+    }
 }

--- a/scide_vscode/LSPDocument.sc
+++ b/scide_vscode/LSPDocument.sc
@@ -41,7 +41,7 @@ LSPDocument : Document {
     
     *open { | path, selectionStart=0, selectionLength=0, envir |
         LSPConnection.connection.request('window/showDocument', (
-            uri: "file:///%".format(path.standardizePath),
+            uri: path.standardizePath.pathToFileURI,
             takeFocus: true,
             // selection:
         ))
@@ -55,7 +55,7 @@ LSPDocument : Document {
             uri,
             string,
             false,
-            uri.copy.replace("file:///", "").urlDecode,
+            uri.copy.fileURIToPath,
             0,
             0
         );
@@ -178,8 +178,8 @@ LSPDocument : Document {
     }
     
     path {
-        if (quuid.contains("file:///")) {
-            ^quuid.copy.replace("file:///", "").urlDecode
+        if (quuid.contains("file://")) {
+            ^quuid.copy.fileURIToPath
         } {
             ^nil
         }

--- a/scide_vscode/LSPDocument.sc
+++ b/scide_vscode/LSPDocument.sc
@@ -41,7 +41,7 @@ LSPDocument : Document {
     
     *open { | path, selectionStart=0, selectionLength=0, envir |
         LSPConnection.connection.request('window/showDocument', (
-            uri: "file://%".format(path.standardizePath),
+            uri: "file:///%".format(path.standardizePath),
             takeFocus: true,
             // selection:
         ))
@@ -55,7 +55,7 @@ LSPDocument : Document {
             uri,
             string,
             false,
-            uri.copy.replace("file://", "").urlDecode,
+            uri.copy.replace("file:///", "").urlDecode,
             0,
             0
         );
@@ -178,8 +178,8 @@ LSPDocument : Document {
     }
     
     path {
-        if (quuid.contains("file://")) {
-            ^quuid.copy.replace("file://", "").urlDecode
+        if (quuid.contains("file:///")) {
+            ^quuid.copy.replace("file:///", "").urlDecode
         } {
             ^nil
         }


### PR DESCRIPTION
Fixes https://github.com/scztt/vscode-supercollider/issues/64 .

On Windows, SC gives paths that look like "C:\blah\blah.sc". VSCode wants the final path to be "file:///c:/blah/blah.sc". 

I've tried to find all the places where conversion was being done to / from a file URI and added new string extensions `pathToFileURI` and `fileURIToPath` to handle the conversion in an OS-independent way.

I've tested this on both OSX and Windows, but it's possible since I'm fairly new to this that I've missed a case. I also tested with paths that contain spaces since that can be another gotcha, and that seems to be working with this change. Let me know if some specific piece isn't working right! I assume Linux doesn't need testing because it handles paths pretty much the same as OSX, but I can test on that if needed. I have all 3 OSes in some form with all this cutting-edge sc stuff ready to go.

The specific places in the code I wasn't quite sure how to actually trigger:
1. The EvaluateProvider change.
2. The InitializeProvider change.
3. The LSPDocument change.


