### PR TITLE
Platform: don't replace startupFiles if no LSP

### DIFF
--- a/SystemOverwrites/extMain.sc
+++ b/SystemOverwrites/extMain.sc
@@ -71,7 +71,11 @@
 
 +Platform {
     startupFiles {
-        ^InitializeProvider.startupFiles
+        if (LSPConnection.enabled) {
+            ^InitializeProvider.startupFiles;
+        } {
+            ^[defaultStartupFile];
+        };
     }
 }
 


### PR DESCRIPTION
Currently `+Platform` overwrites `Platform.startupFiles` to hand it to `InitializationProvider`, but the latter only decides on startup files if LSPConnection is enabled when the init message is received. As a result, when not using LSP, sclang has startupFiles = nil and ignores the default "startup.scd".
